### PR TITLE
Support building container images for both dev & prod environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,9 @@ RUN yarn install --prod
 
 # STAGE: Prod Deploy Ready Image
 FROM node:carbon-alpine AS prod
-
 EXPOSE 8848
 WORKDIR /app
 COPY public /app/public
 COPY --from=builder /app/dist /app/dist
 COPY --from=prod-dependencies /app/node_modules /app/node_modules
-
 CMD ["node", "dist/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ FROM node:carbon-alpine AS prod
 
 EXPOSE 8848
 WORKDIR /app
+COPY public /app/public
 COPY --from=builder /app/dist /app/dist
 COPY --from=prod-dependencies /app/node_modules /app/node_modules
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# STAGE: Development
 FROM node:carbon-alpine AS dev
 
 # Port to listen on
@@ -13,3 +14,24 @@ RUN yarn
 ENTRYPOINT ["yarn"]
 CMD ["start:dev"]
 
+# STAGE: Builder
+FROM node:carbon-alpine AS builder
+WORKDIR /app
+COPY --from=dev /app /app
+RUN yarn build
+
+# STAGE: Prod Dependencies Builder
+FROM node:carbon-alpine AS prod-dependencies
+WORKDIR /app
+COPY ["package.json", "yarn.lock", "./"]
+RUN yarn install --prod
+
+# STAGE: Prod Deploy Ready Image
+FROM node:carbon-alpine AS prod
+
+EXPOSE 8848
+WORKDIR /app
+COPY --from=builder /app/dist /app/dist
+COPY --from=prod-dependencies /app/node_modules /app/node_modules
+
+CMD ["node", "dist/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:carbon-alpine
+FROM node:carbon-alpine AS dev
 
 # Port to listen on
 EXPOSE 8848
@@ -7,6 +7,9 @@ EXPOSE 8848
 WORKDIR /app
 COPY . /app/
 
+RUN yarn
+
 # Default app commands
 ENTRYPOINT ["yarn"]
 CMD ["start:dev"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 version: '3.4'
 services:
   express-api-es6-starter:
-    build: .
+    build:
+      context: .
+      target: dev
     volumes:
       - .env.docker:/app/.env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.4'
 services:
   express-api-es6-starter:
     build: .


### PR DESCRIPTION
Support building container images for both dev & prod environments. 
I have used docker [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/) to support targetting builds for either dev or production environments. 

### DEV Image
The only addition in the `dev` docker image is the addition of `RUN yarn` which ensures the image always has the dependencies installed even if you do a docker build in a fresh clone repository. 

```
$ docker build --target=dev -t mesaugat/express-api-es6-starter:dev .
```

### PROD Image
The production image only contains the built `dist/` and the `node_modules/` with the packages installed only for production i.e `devDependencies` are not installed. It uses [`yarn install --prod`](https://yarnpkg.com/lang/en/docs/cli/install/).

```
$ docker build --target=prod -t mesaugat/express-api-es6-starter:prod .
```

Closes #40 