### PR TITLE
Add new stage for running migrations and update docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,7 @@ COPY . /app/
 RUN yarn
 
 # Default app commands
-ENTRYPOINT ["yarn"]
-CMD ["start:dev"]
+CMD ["yarn", "start:dev"]
 
 # STAGE: Builder
 FROM node:carbon-alpine AS builder
@@ -25,6 +24,12 @@ FROM node:carbon-alpine AS prod-dependencies
 WORKDIR /app
 COPY ["package.json", "yarn.lock", "./"]
 RUN yarn install --prod
+
+# STAGE: Run Migrations
+FROM dev AS migrate
+WORKDIR /app
+COPY --from=dev /app /app
+CMD yarn migrate && yarn seed
 
 # STAGE: Prod Deploy Ready Image
 FROM node:carbon-alpine AS prod

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,11 +25,17 @@ WORKDIR /app
 COPY ["package.json", "yarn.lock", "./"]
 RUN yarn install --prod
 
-# STAGE: Run Migrations
+# STAGE: Run migrations
 FROM dev AS migrate
 WORKDIR /app
 COPY --from=dev /app /app
 CMD yarn migrate && yarn seed
+
+# STAGE: Rollback migrations
+FROM dev AS migrate-rollback
+WORKDIR /app
+COPY --from=dev /app /app
+CMD yarn rollback
 
 # STAGE: Prod Deploy Ready Image
 FROM node:carbon-alpine AS prod

--- a/README.md
+++ b/README.md
@@ -89,8 +89,7 @@ Bring down stack,
 
 ### Multi-stage docker builds
 
-There are multiple build targets available for different stages.
-These images could be used to deploy or run jobs in different container based cloud infrastructure like Kubernetes, AWS ECS, Fargate, GCP Cloud Run etc.
+There are multiple build targets available for different stages. These images can be used to deploy or run jobs in different container based cloud infrastructure like Kubernetes, AWS ECS, Fargate, GCP Cloud Run etc.
 
 1. Building a production image.
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ Example,
     $ yarn make:migration create_tags_table
     $ yarn make:seeder 02_insert_tags
 
-## Setup Using Docker
+## Using Docker
+
+#### Using docker-compose
 
 Use [docker-compose](https://docs.docker.com/compose/) to quickly bring up a stack with pre-configured Postgres database container. Data is ephemeral and containers will disappear when stack is removed.
 
@@ -84,6 +86,39 @@ Navigate to http://localhost:8848/api-docs/ to verify application is running fro
 Bring down stack,
 
     $ docker-compose down
+
+#### Multi-stage docker builds
+
+There are multiple build targets available for different stages.
+These images could be used to deploy or run jobs in different container based cloud infrastructure like Kubernetes, AWS ECS, Fargate, GCP Cloud Run etc.
+
+1. Building a production image.
+
+   ```bash
+   $ docker build --target=prod -t express-api-es6-starter:prod .
+   ```
+
+2. Building an image for development.
+
+   ```bash
+   $ docker build --target=dev -t express-api-es6-starter:dev .
+   ```
+
+3. Building an image that runs migration and/or rollback.
+
+   ```bash
+    # Docker image that runs migration and seeds.
+    $ docker build --target=migrate -t express-api-es6-starter:migrate .
+
+    # Docker image that rollbacks migrations.
+    $ docker build --target=migrate-rollback -t express-api-es6-starter:migrate-rollback .
+   ```
+
+Once the images have been built - all you need to do is run them providing a `.env` file. Like this:
+
+```bash
+$ docker run -v"/path/to/your/.env:/app/.env" mesaugat/express-api-es6-starter:migrate
+```
 
 ## Using MySQL instead of PostgreSQL
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Example,
 
 ## Using Docker
 
-#### Using docker-compose
+### Using docker-compose
 
 Use [docker-compose](https://docs.docker.com/compose/) to quickly bring up a stack with pre-configured Postgres database container. Data is ephemeral and containers will disappear when stack is removed.
 
@@ -87,7 +87,7 @@ Bring down stack,
 
     $ docker-compose down
 
-#### Multi-stage docker builds
+### Multi-stage docker builds
 
 There are multiple build targets available for different stages.
 These images could be used to deploy or run jobs in different container based cloud infrastructure like Kubernetes, AWS ECS, Fargate, GCP Cloud Run etc.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,19 @@ services:
       - .env.docker:/app/.env
     ports:
       - '8848:8848'
-    entrypoint: /bin/sh
-    command: -c "sleep 5 && yarn migrate && yarn seed && yarn start:dev"
+    depends_on:
+      - pg
+      - pg_test
+    links:
+      - pg
+      - pg_test
+
+  migration:
+    build:
+      context: .
+      target: migrate
+    volumes:
+      - .env.docker:/app/.env
     depends_on:
       - pg
       - pg_test


### PR DESCRIPTION
Resolves https://github.com/mesaugat/express-api-es6-starter/issues/43

**Changes**
 - Add a new stage for migrations - `migrate`
 - Add a new stage for rolling back migrations - `migrate-rollback`
 - Update documentation for building images for specific targets - prod, dev, etc
 - Update `docker-compose` to add a container just to run migrations. 

**Preview**
This is how you run migrations with docker-compose. 
![image](https://user-images.githubusercontent.com/3315763/67615857-01bf3d00-f7f1-11e9-8915-49e2439d7681.png)

And this is how you build and  run migrations using plain docker. 
![image](https://user-images.githubusercontent.com/3315763/67615864-22879280-f7f1-11e9-8fbd-5383b092c5ac.png)

![image](https://user-images.githubusercontent.com/3315763/67615875-3b904380-f7f1-11e9-8224-9fc9a054f280.png)

